### PR TITLE
making more friendly for invocation as a class

### DIFF
--- a/xfinity_usage.py
+++ b/xfinity_usage.py
@@ -47,6 +47,9 @@ The latest version of this script can be found at:
 CHANGELOG
 ---------
 
+2017-06-30 Jeff Billimek <jeff@billimek.com>:
+  - making more friendly for invocation as a class
+
 2017-06-22 Jason Antman <jason@jasonantman.com>:
   - clarify PhantomJS requirement of 2.x (2.1.1 recommended)
 

--- a/xfinity_usage.py
+++ b/xfinity_usage.py
@@ -122,6 +122,8 @@ class XfinityUsage(object):
         :type cookie_file: str
         """
         self._screenshot = debug
+        if debug:
+            set_log_debug()
         if username is None or password is None:
             raise RuntimeError("Username and password cannot be None")
         self.username = username
@@ -131,7 +133,6 @@ class XfinityUsage(object):
                           'Gecko/20100101 Firefox/33.0'
         self.cookie_file = cookie_file
         logger.debug('Getting browser instance...')
-        self.browser = self.get_browser()
 
     def run(self):
         """
@@ -139,6 +140,7 @@ class XfinityUsage(object):
         """
         logger.debug('Getting page...')
         try:
+            self.browser = self.get_browser()
             self.get_usage_page()
             res = self.get_usage()
             self.browser.quit()


### PR DESCRIPTION
when running this as a class instead of a standalone app,
self.get_browser() is invoked at class instantiation time
but during the execution of run(), self.browser.quit() is
invoked which removes the session.

If run() is being invoked from a loop, the next time around
it will throw exceptions and generally not be good

This commit moves the browser creation and teardown to occur
wholly within the run() method.

Also added better debugging support for class-based invocation