### PR TITLE
Issues/13

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - Fix ``run()`` method exception handler calling ``.quit()`` on missing ``browser`` attribute when ``get_browser()`` raises an exception, causing a confusing traceback.
+- Fix issue where ``remember_me`` checkbox is not clickable using Chrome Headless, resulting in "Element is not clickable" / "Other element would receive the click" error.
 
 2.0.1 (2017-12-18)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+2.0.2 (2018-02-12)
+------------------
+
+- Fix ``run()`` method exception handler calling ``.quit()`` on missing ``browser`` attribute when ``get_browser()`` raises an exception, causing a confusing traceback.
+
 2.0.1 (2017-12-18)
 ------------------
 

--- a/xfinity_usage/xfinity_usage.py
+++ b/xfinity_usage/xfinity_usage.py
@@ -102,6 +102,7 @@ class XfinityUsage(object):
         self.username = username
         self.password = password
         self.browser_name = browser_name
+        self.browser = None
         self._screenshot_num = 1
         self.user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36' \
                           ' (KHTML, like Gecko) Chrome/62.0.3202.62 ' \
@@ -121,7 +122,8 @@ class XfinityUsage(object):
             self.browser.quit()
             return res
         except Exception:
-            self.browser.quit()
+            if self.browser is not None:
+                self.browser.quit()
             raise
 
     def do_login(self):

--- a/xfinity_usage/xfinity_usage.py
+++ b/xfinity_usage/xfinity_usage.py
@@ -152,7 +152,11 @@ class XfinityUsage(object):
                 rem_me = self.browser.find_element_by_id('remember_me')
                 if not rem_me.is_selected():
                     logger.debug('Clicking "Remember Me"')
-                    rem_me.click()
+                    # because of layering issues, for chrome-headless we need to
+                    # click the containing span instead of the checkbox itself.
+                    self.browser.find_element_by_id(
+                        'remember_me_checkbox'
+                    ).click()
             except Exception:
                 self.error_screenshot()
                 logger.warning('Unable to find Remember Me button!',


### PR DESCRIPTION
- Fix ``run()`` method exception handler calling ``.quit()`` on missing ``browser`` attribute when ``get_browser()`` raises an exception, causing a confusing traceback.
- Fix issue where ``remember_me`` checkbox is not clickable using Chrome Headless, resulting in "Element is not clickable" / "Other element would receive the click" error.