### PR TITLE
Add support for raw JSON data and scrape time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,13 @@
 Changelog
 =========
 
-2.0.3 (2018-04-14)
+3.0.0 (2018-04-18)
 -----------------
 
-- Add support for raw JSON data and scrape time
+- Get raw JSON data from the ``https://customer.xfinity.com/apis/services/internet/usage`` endpoint.
+- If the above succeeds, use this for data source instead of screen-scraping the page.
+- Add raw JSON data from above to output in "raw" key.
+- Add scrape time to JSON output in "data_timestamp" key.
 
 2.0.2 (2018-02-12)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+2.0.3 (2018-04-14)
+-----------------
+
+- Add support for raw JSON data and scrape time
+
 2.0.2 (2018-02-12)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,79 @@ and ``run`` methods of the ``XfinityUsage`` class. As a simple example:
    >>> from xfinity_usage.xfinity_usage import XfinityUsage
    >>> u = XfinityUsage(os.environ['XFINITY_USER'], os.environ['XFINITY_PASSWORD'], browser_name='chrome-headless')
    >>> u.run()
-   {'units': 'GB', 'used': 553.0, 'total': 1024.0}
+   {
+       "data_timestamp": 1523913455,
+       "units": "GB",
+       "used": 224.0,
+       "total": 1024.0,
+       "raw": {
+           "courtesyUsed": 0,
+           "courtesyRemaining": 2,
+           "courtesyAllowed": 2,
+           "inPaidOverage": false,
+           "usageMonths": [
+               {
+                   "policyName": "1 Terabyte Data Plan",
+                   "startDate": "10/01/2017",
+                   "endDate": "10/31/2017",
+                   "homeUsage": 408.0,
+                   "allowableUsage": 1024.0,
+                   "unitOfMeasure": "GB",
+                   "devices": [
+                       {
+                           "id": "AB:CD:EF:01:23:45",
+                           "usage": 301.0
+                       },
+                       {
+                           "id": "12:34:56:78:90:AB",
+                           "usage": 107.0
+                       }
+                   ],
+                   "additionalBlocksUsed": 0.0,
+                   "additionalCostPerBlock": 10.0,
+                   "additionalUnitsPerBlock": 50.0,
+                   "additionalIncluded": 0.0,
+                   "additionalUsed": 0.0,
+                   "additionalPercentUsed": 0.0,
+                   "additionalRemaining": 0.0,
+                   "billableOverage": 0.0,
+                   "overageCharges": 0.0,
+                   "overageUsed": 0.0,
+                   "currentCreditAmount": 0,
+                   "maxCreditAmount": 0,
+                   "policy": "limited"
+               },
+               # 5 additional months removed for brevity
+               {
+                   "policyName": "1 Terabyte Data Plan",
+                   "startDate": "04/01/2018",
+                   "endDate": "04/30/2018",
+                   "homeUsage": 224.0,
+                   "allowableUsage": 1024.0,
+                   "unitOfMeasure": "GB",
+                   "devices": [
+                       {
+                           "id": "12:34:56:78:90:AB",
+                           "usage": 224.0
+                       }
+                   ],
+                   "additionalBlocksUsed": 0.0,
+                   "additionalCostPerBlock": 10.0,
+                   "additionalUnitsPerBlock": 50.0,
+                   "additionalIncluded": 0.0,
+                   "additionalUsed": 0.0,
+                   "additionalPercentUsed": 0.0,
+                   "additionalRemaining": 0.0,
+                   "billableOverage": 0.0,
+                   "overageCharges": 0.0,
+                   "overageUsed": 0.0,
+                   "currentCreditAmount": 0,
+                   "maxCreditAmount": 0,
+                   "policy": "limited"
+               }
+           ]
+       }
+   }
 
 Note About Reliability
 ----------------------

--- a/xfinity_usage/version.py
+++ b/xfinity_usage/version.py
@@ -35,5 +35,5 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 ##################################################################################
 """
 
-VERSION = '2.0.3'
+VERSION = '3.0.0'
 PROJECT_URL = 'https://github.com/jantman/xfinity-usage'

--- a/xfinity_usage/version.py
+++ b/xfinity_usage/version.py
@@ -35,5 +35,5 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 ##################################################################################
 """
 
-VERSION = '2.0.2'
+VERSION = '2.0.3'
 PROJECT_URL = 'https://github.com/jantman/xfinity-usage'

--- a/xfinity_usage/xfinity_usage.py
+++ b/xfinity_usage/xfinity_usage.py
@@ -229,9 +229,20 @@ class XfinityUsage(object):
         self.do_screenshot()
 
     def get_usage_json(self):
+        """Return the JSON usage information from the internal API url."""
+        logger.debug('Getting usage JSON from: %s', self.JSON_URL)
         self.get(self.JSON_URL)
         self.wait_for_page_load()
         self.do_screenshot()
+        raw = self.browser.find_element_by_tag_name('pre').text
+        try:
+            return json.loads(raw)
+        except Exception:
+            logger.error(
+                'Exception loading JSON from <pre> content: %s',
+                raw, exc_info=True
+            )
+            raise
 
     def get_usage(self):
         """
@@ -291,9 +302,6 @@ class XfinityUsage(object):
             )
         return {'units': used_unit, 'used': used, 'total': total,
                 'now': int(time.time())}
-
-    def parse_json(self):
-        return json.loads(self.browser.find_element_by_tag_name('pre').text)
 
     def do_screenshot(self):
         """take a debug screenshot"""

--- a/xfinity_usage/xfinity_usage.py
+++ b/xfinity_usage/xfinity_usage.py
@@ -77,6 +77,7 @@ class XfinityUsage(object):
     """Class to screen-scrape Xfinity site for usage information."""
 
     USAGE_URL = 'https://customer.xfinity.com/#/devices'
+    JSON_URL = 'https://customer.xfinity.com/apis/services/internet/usage'
 
     def __init__(self, username, password, debug=False,
                  cookie_file='cookies.json', browser_name='phantomjs'):
@@ -119,6 +120,8 @@ class XfinityUsage(object):
             self.browser = self.get_browser()
             self.get_usage_page()
             res = self.get_usage()
+            self.get_usage_json()
+            res['raw'] = self.parse_json()
             self.browser.quit()
             return res
         except Exception:
@@ -225,6 +228,11 @@ class XfinityUsage(object):
                         'login may have failed.')
         self.do_screenshot()
 
+    def get_usage_json(self):
+        self.get(self.JSON_URL)
+        self.wait_for_page_load()
+        self.do_screenshot()
+
     def get_usage(self):
         """
         Get the actual usage from the page
@@ -281,7 +289,11 @@ class XfinityUsage(object):
                     used_unit, total_unit
                 )
             )
-        return {'units': used_unit, 'used': used, 'total': total}
+        return {'units': used_unit, 'used': used, 'total': total,
+                'now': int(time.time())}
+
+    def parse_json(self):
+        return json.loads(self.browser.find_element_by_tag_name('pre').text)
 
     def do_screenshot(self):
         """take a debug screenshot"""

--- a/xfinity_usage/xfinity_usage.py
+++ b/xfinity_usage/xfinity_usage.py
@@ -46,7 +46,7 @@ import json
 import codecs
 import time
 import re
-from datetime import datetime, date
+from datetime import datetime
 import socket
 from operator import itemgetter
 from copy import deepcopy


### PR DESCRIPTION
Adds support for raw JSON data from the usage API and the scrape time.

The raw JSON data exposes a lot more data and the scrape time is useful for other systems to know the age of the response.

# Pull Request Checklist

- [X] All pull requests must include the Contributor License Agreement (see below).
- [X] Code should conform to the following:
    - [X] pep8 compliant with some exceptions (see pytest.ini)
    - [X] Complete, correctly-formatted documentation for all classes, functions and methods.
    - [X] Code works under Python 2.7 and Python 3.3+
    - [X] **Commit messages** should be meaningful, and reference the Issue number
      if you're working on a GitHub issue (i.e. "issue #x - <message>"). Please
      refrain from using the "fixes #x" notation unless you are *sure* that the
      the issue is fixed in that commit.
    - [X] Git history is fully intact; please do not squash or rewrite history.
- [X] If you're sure your code works, adding a relevant entry to ``CHANGES.rst`` and
  bumping the version number in ``xfinity_usage/version.py`` will get it merged and
  released faster.

## Contributor License Agreement

By submitting this work for inclusion in xfinity-usage, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the xfinity-usage project (the Affero GPL v3,
  or any subsequent version of that license if adopted by xfinity-usage).
* My contribution may perpetually be included in and distributed with xfinity-usage; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of xfinity-usage's license.
* I have the legal power and rights to agree to these terms.
