### PR TITLE
Fix pep8 test causing failures on Python versions >3.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,15 +6,18 @@ deps =
   cov-core
   coverage
   execnet
-  pep8
   py
-  pytest>=2.8.3
+  py{27,34,35}: pytest>=2.8.3,<6.0.0
+  py36: pytest>=2.8.3
   pytest-cache
   pytest-cov
-  pytest-pep8
+  py{27,34,35}: pep8
+  py{27,34,35}: pytest-pep8
+  py36: pytest-pycodestyle
   pytest-flakes
   pytest-blockage
   selenium
+  virtualenv
 
 passenv=TRAVIS*
 setenv =
@@ -28,7 +31,12 @@ commands =
     virtualenv --version
     pip --version
     pip freeze
-    py.test -rxs -vv --durations=10 --pep8 --flakes --blockage --cov-report term-missing --cov-report xml --cov-report html --cov-config {toxinidir}/.coveragerc --cov=xfinity_usage {posargs} xfinity_usage
+    py{27,34,35}: py.test -rxs -vv --durations=10 --pep8 --flakes --blockage --cov-report term-missing --cov-report xml --cov-report html --cov-config {toxinidir}/.coveragerc --cov=xfinity_usage {posargs} xfinity_usage
+    py36: py.test -rxs -vv --durations=10 --pycodestyle --flakes --blockage --cov-report term-missing --cov-report xml --cov-report html --cov-config {toxinidir}/.coveragerc --cov=xfinity_usage {posargs} xfinity_usage
+
 
 # always recreate the venv
 recreate = True
+
+[pycodestyle]
+max-line-length = 80


### PR DESCRIPTION
__IMPORTANT:__ Please take note of the below checklist, especially the first two items.

# Pull Request Checklist

- [x] All pull requests must include the Contributor License Agreement (see below).
- [x] Code should conform to the following:
    - [x] pep8 compliant with some exceptions (see pytest.ini)
    - [x] Complete, correctly-formatted documentation for all classes, functions and methods.
    - [x] Code works under Python 2.7 and Python 3.3+
    - [x] **Commit messages** should be meaningful, and reference the Issue number
      if you're working on a GitHub issue (i.e. "issue #x - <message>"). Please
      refrain from using the "fixes #x" notation unless you are *sure* that the
      the issue is fixed in that commit.
    - [x] Git history is fully intact; please do not squash or rewrite history.
- [x] If you're sure your code works, adding a relevant entry to ``CHANGES.rst`` and
  bumping the version number in ``xfinity_usage/version.py`` will get it merged and
  released faster.

## Contributor License Agreement

By submitting this work for inclusion in xfinity-usage, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the xfinity-usage project (the Affero GPL v3,
  or any subsequent version of that license if adopted by xfinity-usage).
* My contribution may perpetually be included in and distributed with xfinity-usage; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of xfinity-usage's license.
* I have the legal power and rights to agree to these terms.
