### PR TITLE
issue #30 - Added firefox-headless as new browser type & default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+3.0.4 (2020-09-15)
+------------------
+- Made new firefox-headless browser the new default browser (since it works)
+- Added options to firefox-headless to avoid bot checks when getting usage from xfinity's site
+- Cleaned up -b argument help message and choices
+
 3.0.3 (2018-10-30)
 ------------------
 

--- a/xfinity_usage/version.py
+++ b/xfinity_usage/version.py
@@ -35,5 +35,5 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 ##################################################################################
 """
 
-VERSION = '3.0.3'
+VERSION = '3.0.4'
 PROJECT_URL = 'https://github.com/jantman/xfinity-usage'

--- a/xfinity_usage/xfinity_usage.py
+++ b/xfinity_usage/xfinity_usage.py
@@ -75,7 +75,9 @@ selenium_log.setLevel(logging.INFO)
 selenium_log.propagate = True
 
 # supported browsers
-browsers = ['phantomjs', 'firefox', 'firefox-headless', 'chrome', 'chrome-headless']
+browsers = ['phantomjs', 'firefox', 'firefox-headless',
+            'chrome', 'chrome-headless']
+
 
 class XfinityUsage(object):
     """Class to screen-scrape Xfinity site for usage information."""
@@ -402,7 +404,8 @@ class XfinityUsage(object):
             profile.set_preference("dom.webdriver.enabled", False)
             profile.set_preference('useAutomationExtension', False)
             profile.update_preferences()
-            browser = webdriver.Firefox(firefox_profile=profile, firefox_options=options)
+            browser = webdriver.Firefox(firefox_profile=profile,
+                                        firefox_options=options)
         elif self.browser_name == 'chrome':
             logger.debug("getting Chrome browser (local)")
             browser = webdriver.Chrome()
@@ -603,9 +606,11 @@ def parse_args(argv):
                    type=str,
                    default=os.path.realpath('xfinity_usage_cookies.json'),
                    help='File to save cookies in')
-    p.add_argument('-b', '--browser', dest='browser_name', type=str, metavar='BROWSER',
-                   default='firefox-headless', choices=browsers,
-                   help='Browser name/type to use (default: firefox-headless): {}'.format(','.join(browsers)))
+    p.add_argument('-b', '--browser', dest='browser_name', type=str,
+                   metavar='BROWSER', default='firefox-headless',
+                   choices=browsers,
+                   help='Browser name/type to use (default: {}): {}'.format(
+                        'firefox-headless',','.join(browsers)))
     p.add_argument('-j', '--json', dest='json', action='store_true',
                    default=False, help='output JSON')
     p.add_argument('-g', '--graphite', action='store_true', default=False,

--- a/xfinity_usage/xfinity_usage.py
+++ b/xfinity_usage/xfinity_usage.py
@@ -610,7 +610,7 @@ def parse_args(argv):
                    metavar='BROWSER', default='firefox-headless',
                    choices=browsers,
                    help='Browser name/type to use (default: {}): {}'.format(
-                        'firefox-headless',','.join(browsers)))
+                        'firefox-headless', ','.join(browsers)))
     p.add_argument('-j', '--json', dest='json', action='store_true',
                    default=False, help='output JSON')
     p.add_argument('-g', '--graphite', action='store_true', default=False,


### PR DESCRIPTION
Cleaned up -b argument help message and choices
Made new firefox-headless browser the new default browser (since it works)
Added options to firefox-headless to avoid bot checks when getting usage from xfinity's site

## Contributor License Agreement

By submitting this work for inclusion in xfinity-usage, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the xfinity-usage project (the Affero GPL v3,
  or any subsequent version of that license if adopted by xfinity-usage).
* My contribution may perpetually be included in and distributed with xfinity-usage; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of xfinity-usage's license.
* I have the legal power and rights to agree to these terms.
